### PR TITLE
Implement checking against historic test coverage

### DIFF
--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -112,8 +112,8 @@ jobs:
 
             if (( $(echo "$total_persist > $total_rate" | bc -l) ))
             then
-              echo "::error title=Branch coverage failure::Test coverage has dropped from $total_persist to $total_rate"
-              exit 1
+              echo "::setFailed title=Branch coverage failure::Test coverage has dropped from $total_persist to $total_rate"
+              #exit 1
             else
               echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"
             fi
@@ -123,8 +123,8 @@ jobs:
           else
             echo "First time coverage reporting for $REPO@$BRANCH"
           fi
-
-          echo "$REPO,$BRANCH,$total_rate,$integ_rate,$unit_rate" >> repos.csv
-          aws s3 cp repos.csv $COVERAGE_S3_PATH
-          exit 0
+          echo "Got HERE!"
+          #echo "$REPO,$BRANCH,$total_rate,$integ_rate,$unit_rate" >> repos.csv
+          #aws s3 cp repos.csv $COVERAGE_S3_PATH
+          #exit 0
 

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -112,7 +112,6 @@ jobs:
 
             if (( $(echo "$total_persist > $total_rate" | bc -l) ))
             then
-              echo "ERROR: Test coverage has dropped from $total_persist to $total_rate"
               echo "::error title=Branch coverage failure::Test coverage has dropped from $total_persist to $total_rate"
               exit 1
             else

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -10,10 +10,15 @@ on:
         type: number
       DOCKER_COMPOSE:   # Path to docker-compose.yml file: If populated, spins up containers required for integration tests
         type: string
+      AWS_REGION:
+        type: string
     secrets:
       PKG_TOKEN:
         required: true
-
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
 
 jobs:
   xunit:
@@ -46,6 +51,13 @@ jobs:
         
       - name: Run report generation
         run: reportgenerator -reports:$GITHUB_WORKSPACE/*/TestResults/*/coverage.cobertura.xml -targetdir:$RUNNER_TEMP/coverlet/reports -reporttypes:"cobertura"
+
+      - name: Configure AWS credentials (ECR_REGION_1)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Check Branch Coverage
         id: coverage

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -80,7 +80,7 @@ jobs:
           total_rate=$(get_branch "$RUNNER_TEMP/coverlet/reports/Cobertura.xml")
           integ_rate=$(get_branch "$integ_report")
           unit_rate=$(get_branch "$unit_report")
-          echo "Coverage for $REPO@REF -- Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
+          echo "Coverage for $REPO@$REF -- Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
           
           aws s3 cp $COVERAGE_S3_PATH repos.csv
           record_exists=$(cat repos.csv | grep "^$REPO,$REF," | wc -l)

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -49,8 +49,44 @@ jobs:
 
       - name: Check Branch Coverage
         id: coverage
-        uses: amdigital-co-uk/code-coverage-action@v1.0
-        with:
-          path: ${{ runner.temp }}/coverlet/reports/Cobertura.xml
-          branch_minimum_threshold: ${{ inputs.BRANCH_THRESHOLD }}
+        env:
+          COVERAGE_S3_PATH: s3://amdigital-co-uk-code-audits/code-coverage/repos.csv
+          REPO: ${{ github.repository }}
+          REF: ${{ github.ref_name }}
+        run: |
+          get_branch() {
+            if [ -f "$1" ]; then
+              cat "$1" | sed -e 's/\r//g' | grep -Po --color=never '<coverage.+branch-rate="\K[^"]+' | head -c 6
+            else
+              echo 0
+            fi
+          }
+
+          integ_report=$(find . -iname coverage.cobertura.xml | grep "\.IntegrationTest")
+          unit_report=$(find . -iname coverage.cobertura.xml | grep "\.Test")
+
+          total_rate=$(get_branch "$RUNNER_TEMP/coverlet/reports/Cobertura.xml")
+          integ_rate=$(get_branch "$integ_report")
+          unit_rate=$(get_branch "$unit_report")
+          aws s3 cp $COVERAGE_S3_PATH repos.csv
+          record=$(cat repos.csv | grep "^$REPO,$REF,")
+
+          if [ -n "$record" ]
+          then
+            total_persist=$(echo $record | cut -d, -f3)
+            integ_persist=$(echo $record | cut -d, -f4)
+            unit_persist=$(echo $record | cut -d, -f5)
+
+            if (( $(echo "$total_persist > $total_rate" | bc -l) ))
+            then
+              echo "ERROR: Test coverage has dropped from $total_persist to $total_rate"
+              exit 1
+            fi
+
+            cat repos.csv | grep -v "^$REPO,$REF," > repos.tmp
+            mv repos.tmp repos.csv
+          fi
+
+          echo "$REPO,$REF,$total_rate,$integ_rate,$unit_rate" >> repos.csv
+          aws s3 cp repos.csv $COVERAGE_S3_PATH
 

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -16,7 +16,7 @@ on:
         type: string
       NEVER_FAIL_AT:
         type: number
-        default: 40
+        default: 0.4
       AWS_REGION:
         type: string
         default: us-east-1

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -104,6 +104,8 @@ jobs:
 
             cat repos.csv | grep -v "^$REPO,$BRANCH," > repos.tmp
             mv repos.tmp repos.csv
+          else
+            echo "First time coverage reporting for $REPO@$BRANCH"
           fi
 
           echo "$REPO,$BRANCH,$total_rate,$integ_rate,$unit_rate" >> repos.csv

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -80,6 +80,8 @@ jobs:
           total_rate=$(get_branch "$RUNNER_TEMP/coverlet/reports/Cobertura.xml")
           integ_rate=$(get_branch "$integ_report")
           unit_rate=$(get_branch "$unit_report")
+          echo "Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
+          
           aws s3 cp $COVERAGE_S3_PATH repos.csv
           record=$(cat repos.csv | grep "^$REPO,$REF,")
 
@@ -93,6 +95,8 @@ jobs:
             then
               echo "ERROR: Test coverage has dropped from $total_persist to $total_rate"
               exit 1
+            else
+              echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"
             fi
 
             cat repos.csv | grep -v "^$REPO,$REF," > repos.tmp
@@ -101,4 +105,5 @@ jobs:
 
           echo "$REPO,$REF,$total_rate,$integ_rate,$unit_rate" >> repos.csv
           aws s3 cp repos.csv $COVERAGE_S3_PATH
+          exit 0
 

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -112,8 +112,8 @@ jobs:
 
             if (( $(echo "$total_persist > $total_rate" | bc -l) ))
             then
-              echo "::setFailed::Test coverage has dropped from $total_persist to $total_rate"
-              #exit 1
+              echo "::error title=Branch coverage failure::Test coverage has dropped from $total_persist to $total_rate"
+              exit 1
             else
               echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"
             fi
@@ -123,8 +123,8 @@ jobs:
           else
             echo "First time coverage reporting for $REPO@$BRANCH"
           fi
-          echo "Got HERE!"
-          #echo "$REPO,$BRANCH,$total_rate,$integ_rate,$unit_rate" >> repos.csv
-          #aws s3 cp repos.csv $COVERAGE_S3_PATH
-          #exit 0
+
+          echo "$REPO,$BRANCH,$total_rate,$integ_rate,$unit_rate" >> repos.csv
+          aws s3 cp repos.csv $COVERAGE_S3_PATH
+          exit 0
 

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -14,6 +14,9 @@ on:
         default: 0
       COVERAGE_S3_PATH: # S3 path of the CSV that stores historic coverage data (file can contain multiple repos/branches)
         type: string
+      NEVER_FAIL_AT:
+        type: number
+        default: 40
       AWS_REGION:
         type: string
         default: us-east-1
@@ -112,8 +115,13 @@ jobs:
 
             if (( $(echo "$total_persist > $total_rate" | bc -l) ))
             then
-              echo "::error title=Branch coverage failure::Test coverage has dropped from $total_persist to $total_rate"
-              exit 1
+              if (( $(echo "${{inputs.NEVER_FAIL_AT}} < $total_rate" | bc -l) ))
+              then
+                echo "::notice title=Branch coverage fallen::Test coverage has dropped from $total_persist to $total_rate, but is still above ${{inputs.NEVER_FAIL_AT}} "
+              else
+                echo "::error title=Branch coverage failure::Test coverage has dropped from $total_persist to $total_rate"
+                exit 1
+              fi
             else
               echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"
             fi

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -16,7 +16,7 @@ on:
         type: string
       NEVER_FAIL_AT:
         type: number
-        default: 0.4
+        default: 0.95
       AWS_REGION:
         type: string
         default: us-east-1

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -55,8 +55,7 @@ jobs:
         run: reportgenerator -reports:$GITHUB_WORKSPACE/*/TestResults/*/coverage.cobertura.xml -targetdir:$RUNNER_TEMP/coverlet/reports -reporttypes:"cobertura"
 
       # Compare against static threshold (BRANCH_THRESHOLD is populated)
-      - name: Check Branch Coverage
-        id: coverage
+      - name: Check Branch Coverage against static threshold
         if: ${{ inputs.BRANCH_THRESHOLD > 0 }}
         uses: amdigital-co-uk/code-coverage-action@v1.0
         with:
@@ -72,7 +71,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Check Branch Coverage
+      - name: Check Branch Coverage against historic data
         if: ${{ inputs.BRANCH_THRESHOLD <= 0 }}
         env:
           REPO: ${{ github.repository }}

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -80,16 +80,20 @@ jobs:
           total_rate=$(get_branch "$RUNNER_TEMP/coverlet/reports/Cobertura.xml")
           integ_rate=$(get_branch "$integ_report")
           unit_rate=$(get_branch "$unit_report")
-          echo "Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
+          echo "Coverage for $REPO@$BRANCH -- Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
           
           aws s3 cp $COVERAGE_S3_PATH repos.csv
           record=$(cat repos.csv | grep "^$REPO,$REF,")
+          echo "record=$record"
 
           if [ -n "$record" ]
           then
+            echo "-n record"
             total_persist=$(echo $record | cut -d, -f3)
             integ_persist=$(echo $record | cut -d, -f4)
             unit_persist=$(echo $record | cut -d, -f5)
+
+            echo "Persisted values: $total_persist, $integ_persist, $unit_persist"
 
             if (( $(echo "$total_persist > $total_rate" | bc -l) ))
             then

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -5,20 +5,20 @@ name: Run XUnit Tests
 on:
   workflow_call:
     inputs:
-      BRANCH_THRESHOLD: # Test coverage threshold (integer): workflow will fail if branch coverage does not meet or exceed this threshold
-        required: true
-        type: number
       DOCKER_COMPOSE:   # Path to docker-compose.yml file: If populated, spins up containers required for integration tests
         type: string
-      AWS_REGION:
+      BRANCH_THRESHOLD: # Test coverage threshold (integer): workflow will fail if branch coverage does not meet or exceed this threshold
+                        # If NOT populated, use historic data from previous runs as the threshold.
+                        # Historic data stored in S3, so the AWS secrets must be populated in this instance
+        type: number
+        default: 0
+      COVERAGE_S3_PATH: # S3 path of the CSV that stores historic coverage data (file can contain multiple repos/branches)
         type: string
     secrets:
       PKG_TOKEN:
         required: true
       AWS_ACCESS_KEY_ID:
-        required: true
       AWS_SECRET_ACCESS_KEY:
-        required: true
 
 jobs:
   xunit:
@@ -52,19 +52,30 @@ jobs:
       - name: Run report generation
         run: reportgenerator -reports:$GITHUB_WORKSPACE/*/TestResults/*/coverage.cobertura.xml -targetdir:$RUNNER_TEMP/coverlet/reports -reporttypes:"cobertura"
 
-      - name: Configure AWS credentials (ECR_REGION_1)
+      # Compare against static threshold (BRANCH_THRESHOLD is populated)
+      - name: Check Branch Coverage
+        id: coverage
+        if: ${{ inputs.BRANCH_THRESHOLD > 0 }}
+        uses: amdigital-co-uk/code-coverage-action@v1.0
+        with:
+          path: ${{ runner.temp }}/coverlet/reports/Cobertura.xml
+          branch_minimum_threshold: ${{ inputs.BRANCH_THRESHOLD }}
+
+      # Compare against historic coverage (BRANCH_THRESHOLD is empty or 0, AWS secrets populated)
+      # Historic data stored in a CSV file in S3, and is updated if coverage improves.
+      - name: Configure AWS credentials
+        if: ${{ inputs.BRANCH_THRESHOLD <= 0 }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Check Branch Coverage
-        id: coverage
+        if: ${{ inputs.BRANCH_THRESHOLD <= 0 }}
         env:
-          COVERAGE_S3_PATH: s3://amdigital-co-uk-code-audits/code-coverage/repos.csv
           REPO: ${{ github.repository }}
           BRANCH: ${{ github.ref_name }}
+          COVERAGE_S3_PATH: ${{ inputs.COVERAGE_S3_PATH }}
         run: |
           get_branch() {
             if [ -f "$1" ]; then

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -112,7 +112,7 @@ jobs:
 
             if (( $(echo "$total_persist > $total_rate" | bc -l) ))
             then
-              echo "::setFailed title=Branch coverage failure::Test coverage has dropped from $total_persist to $total_rate"
+              echo "::setFailed::Test coverage has dropped from $total_persist to $total_rate"
               #exit 1
             else
               echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           COVERAGE_S3_PATH: s3://amdigital-co-uk-code-audits/code-coverage/repos.csv
           REPO: ${{ github.repository }}
-          REF: ${{ github.ref_name }}
+          BRANCH: ${{ github.ref_name }}
         run: |
           get_branch() {
             if [ -f "$1" ]; then
@@ -74,27 +74,25 @@ jobs:
             fi
           }
 
+          [ "$BRANCH" = "main" ] || BRANCH=latest
           integ_report=$(find . -iname coverage.cobertura.xml | grep "\.IntegrationTest")
           unit_report=$(find . -iname coverage.cobertura.xml | grep "\.Test")
 
           total_rate=$(get_branch "$RUNNER_TEMP/coverlet/reports/Cobertura.xml")
           integ_rate=$(get_branch "$integ_report")
           unit_rate=$(get_branch "$unit_report")
-          echo "Coverage for $REPO@$REF -- Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
-          
+          echo "Branch coverage rates for $REPO@${{ github.ref_name }} -- Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
+
           aws s3 cp $COVERAGE_S3_PATH repos.csv
-          record_exists=$(cat repos.csv | grep "^$REPO,$REF," | wc -l)
-          echo "record_exists=$record_exists"
+          record_exists=$(cat repos.csv | grep "^$REPO,$BRANCH," | wc -l)
 
           if [ "$record_exists" -gt 0 ]
           then
-            record=$(cat repos.csv | grep "^$REPO,$REF,")
-            echo "-n record"
+            record=$(cat repos.csv | grep "^$REPO,$BRANCH,")
+            
             total_persist=$(echo $record | cut -d, -f3)
             integ_persist=$(echo $record | cut -d, -f4)
             unit_persist=$(echo $record | cut -d, -f5)
-
-            echo "Persisted values: $total_persist, $integ_persist, $unit_persist"
 
             if (( $(echo "$total_persist > $total_rate" | bc -l) ))
             then
@@ -104,11 +102,11 @@ jobs:
               echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"
             fi
 
-            cat repos.csv | grep -v "^$REPO,$REF," > repos.tmp
+            cat repos.csv | grep -v "^$REPO,$BRANCH," > repos.tmp
             mv repos.tmp repos.csv
           fi
 
-          echo "$REPO,$REF,$total_rate,$integ_rate,$unit_rate" >> repos.csv
+          echo "$REPO,$BRANCH,$total_rate,$integ_rate,$unit_rate" >> repos.csv
           aws s3 cp repos.csv $COVERAGE_S3_PATH
           exit 0
 

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -113,6 +113,7 @@ jobs:
             if (( $(echo "$total_persist > $total_rate" | bc -l) ))
             then
               echo "ERROR: Test coverage has dropped from $total_persist to $total_rate"
+              echo "::error title=Branch coverage failure:Test coverage has dropped from $total_persist to $total_rate"
               exit 1
             else
               echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -18,7 +18,9 @@ on:
       PKG_TOKEN:
         required: true
       AWS_ACCESS_KEY_ID:
+        required: false
       AWS_SECRET_ACCESS_KEY:
+        required: false
 
 jobs:
   xunit:

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -14,6 +14,9 @@ on:
         default: 0
       COVERAGE_S3_PATH: # S3 path of the CSV that stores historic coverage data (file can contain multiple repos/branches)
         type: string
+      AWS_REGION:
+        type: string
+        default: us-east-1
     secrets:
       PKG_TOKEN:
         required: true
@@ -70,6 +73,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Check Branch Coverage against historic data
         if: ${{ inputs.BRANCH_THRESHOLD <= 0 }}

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -113,7 +113,7 @@ jobs:
             if (( $(echo "$total_persist > $total_rate" | bc -l) ))
             then
               echo "ERROR: Test coverage has dropped from $total_persist to $total_rate"
-              echo "::error title=Branch coverage failure:Test coverage has dropped from $total_persist to $total_rate"
+              echo "::error title=Branch coverage failure::Test coverage has dropped from $total_persist to $total_rate"
               exit 1
             else
               echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -80,14 +80,15 @@ jobs:
           total_rate=$(get_branch "$RUNNER_TEMP/coverlet/reports/Cobertura.xml")
           integ_rate=$(get_branch "$integ_report")
           unit_rate=$(get_branch "$unit_report")
-          echo "Coverage for $REPO@$BRANCH -- Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
+          echo "Coverage for $REPO@REF -- Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
           
           aws s3 cp $COVERAGE_S3_PATH repos.csv
-          record=$(cat repos.csv | grep "^$REPO,$REF,")
-          echo "record=$record"
+          record_exists=$(cat repos.csv | grep "^$REPO,$REF," | wc -l)
+          echo "record_exists=$record_exists"
 
-          if [ -n "$record" ]
+          if [ "$record_exists" -gt 0 ]
           then
+            record=$(cat repos.csv | grep "^$REPO,$REF,")
             echo "-n record"
             total_persist=$(echo $record | cut -d, -f3)
             integ_persist=$(echo $record | cut -d, -f4)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Note that the secrets are defined at organisation level, so shouldn't need defin
 
 ## Run .NET Core automated tests via XUnit
 
+### Check branch coverage against Static Threshold
+
+Default behaviour when setting `BRANCH_THRESHOLD` is to report test coverage and fail the workflow if it does not meet the threshold.
+
 ```yml
 jobs:
   xunit:
@@ -17,6 +21,27 @@ jobs:
       BRANCH_THRESHOLD: 80
     secrets:
       PKG_TOKEN: ${{ secrets.PKG_TOKEN }}
+```
+
+### Check branch coverage against historic data
+
+Alternatively, when omitting `BRANCH_THRESHOLD` you can instead set the following parameters and secret values, to have the workflow check current test coverage against the last recorded test coverage for the same repository (test coverage values are stored in a CSV in S3 at the configured location).
+
+If coverage goes down, you see a failure; if it is maintained or improved, the new value will be persisted back to S3 as the new threshold for future runs.
+
+```yml
+jobs:
+  xunit:
+    uses: amdigital-co-uk/quartex-workflows/.github/workflows/xunit.yml@v2
+    with:
+      DOCKER_COMPOSE: Quartex.Sample.Service.IntegrationTests/docker-compose.yml
+      COVERAGE_S3_PATH: s3://my-s3-bucket/code-coverage-reporting/repos.csv
+      AWS_REGION: us-west-2   # default is us-east-1
+      NEVER_FAIL_AT: 0.99     # default is 0.95
+    secrets:
+      PKG_TOKEN: ${{ secrets.PKG_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 ```
 
 ## Create and push NuGet packages to private GitHub packages feed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If coverage goes down, you see a failure; if it is maintained or improved, the n
 ```yml
 jobs:
   xunit:
-    uses: amdigital-co-uk/quartex-workflows/.github/workflows/xunit.yml@v2
+    uses: amdigital-co-uk/quartex-workflows/.github/workflows/xunit.yml@vNext
     with:
       DOCKER_COMPOSE: Quartex.Sample.Service.IntegrationTests/docker-compose.yml
       COVERAGE_S3_PATH: s3://my-s3-bucket/code-coverage-reporting/repos.csv


### PR DESCRIPTION
- Store last-seen coverage values for each repo in a CSV (uploaded to S3)
- Run tests and generate coverage reports as previously
- Instead of using the existing `BRANCH_THRESHOLD` parameter, use the last seen-value from previous runs
  - If current test coverage is lower, then fail
  - If test coverage higher, persist the higher value to S3

Required change to calling workflows as follows:
- Add AWS related secrets
- Instead of specifying `BRANCH_THRESHOLD`, set `COVERAGE_S3_PATH` to indicate where the CSV lives

Updated workflow is backwards compatible, so using the existing input parameters without specifying the new ones will simply use the legacy behaviour. This is done by testing whether `BRANCH_THRESHOLD` is populated or not.