### PR TITLE
Implement checking against historic test coverage

### DIFF
--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -150,7 +150,7 @@ jobs:
               cat coverage.csv | grep -v "^$REPO,$BRANCH," > repos.tmp
               mv repos.tmp coverage.csv
           else
-              echo "First time coverage reporting for $REPO@$BRANCH"
+              echo "::notice::First time coverage reporting for $REPO@$BRANCH"
           fi
 
           # Add new coverage values and persist

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -107,7 +107,7 @@ jobs:
           [ "$BRANCH" = "main" ] && PERSIST=true
           [ "$BRANCH" = "main" ] || BRANCH=latest
 
-          aws s3 cp --quiet $COVERAGE_S3_PATH coverage.csv
+          aws s3 cp --quiet $COVERAGE_S3_PATH coverage.csv || true
 
           if [ ! -f "coverage.csv" ]
           then

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -85,7 +85,9 @@ jobs:
           BRANCH: ${{ github.ref_name }}
           COVERAGE_S3_PATH: ${{ inputs.COVERAGE_S3_PATH }}
           NEVER_FAIL_AT: ${{ inputs.NEVER_FAIL_AT }}
+          PERSIST: false
         run: |
+          # Utility Functions
           get_branch() {
               if [ -f "$1" ]; then
                   raw=$(cat "$1" | sed -e 's/\r//g' | grep -Po --color=never '<coverage.+branch-rate="\K[^"]+')
@@ -96,22 +98,34 @@ jobs:
           }
 
           get_record() {
-            local record=$(cat repos.csv | grep "^$1,$2,")
-            [ -z "$record" ] && record=$(cat repos.csv | grep "^$1,$3,")
-            echo $record
+                  local record=$(cat coverage.csv | grep "^$1,$2,")
+                  [ -z "$record" ] && record=$(cat coverage.csv | grep "^$1,$3,")
+                  echo $record
           }
 
+          # Set behaviour based on current branch
+          [ "$BRANCH" = "main" ] && PERSIST=true
           [ "$BRANCH" = "main" ] || BRANCH=latest
+
+          aws s3 cp --quiet $COVERAGE_S3_PATH coverage.csv
+
+          if [ ! -f "coverage.csv" ]
+          then
+              echo "Repository,Branch,Total Branch Rate,Integration Branch Rate,Unit Branch Rate"  > coverage.csv
+              PERSIST=true
+          fi
+
+          # Parse current branch coverage
           integ_report=$(find . -iname coverage.cobertura.xml | grep "\.IntegrationTest")
           unit_report=$(find . -iname coverage.cobertura.xml | grep "\.Test")
-
           total_rate=$(get_branch "$RUNNER_TEMP/coverlet/reports/Cobertura.xml")
           integ_rate=$(get_branch "$integ_report")
           unit_rate=$(get_branch "$unit_report")
           echo "Branch coverage rates for $REPO@$BRANCH -- Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
 
-          aws s3 cp $COVERAGE_S3_PATH repos.csv
-          record=$(get_record "$REPO" "$BRANCH" "main")
+
+          # Parse historic coverage and cross-check
+          record=$(get_record "$REPO" "main" "latest")
 
           if [ -n "$record" ]
           then
@@ -132,13 +146,16 @@ jobs:
                   echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"
               fi
 
-              cat repos.csv | grep -v "^$REPO,$BRANCH," > repos.tmp
-              mv repos.tmp repos.csv
+              # Remove current coverage values
+              cat coverage.csv | grep -v "^$REPO,$BRANCH," > repos.tmp
+              mv repos.tmp coverage.csv
           else
               echo "First time coverage reporting for $REPO@$BRANCH"
           fi
 
-          echo "$REPO,$BRANCH,$total_rate,$integ_rate,$unit_rate" >> repos.csv
-          aws s3 cp repos.csv $COVERAGE_S3_PATH
+          # Add new coverage values and persist
+          echo "$REPO,$BRANCH,$total_rate,$integ_rate,$unit_rate" >> coverage.csv
+          [ "$PERSIST" = "true" ] && aws s3 cp --quiet coverage.csv $COVERAGE_S3_PATH
+
           exit 0
 

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -16,7 +16,7 @@ on:
         type: string
       NEVER_FAIL_AT:
         type: number
-        default: 0.95
+        default: 95
       AWS_REGION:
         type: string
         default: us-east-1
@@ -84,13 +84,21 @@ jobs:
           REPO: ${{ github.repository }}
           BRANCH: ${{ github.ref_name }}
           COVERAGE_S3_PATH: ${{ inputs.COVERAGE_S3_PATH }}
+          NEVER_FAIL_AT: ${{ inputs.NEVER_FAIL_AT }}
         run: |
           get_branch() {
-            if [ -f "$1" ]; then
-              cat "$1" | sed -e 's/\r//g' | grep -Po --color=never '<coverage.+branch-rate="\K[^"]+' | head -c 6
-            else
-              echo 0
-            fi
+              if [ -f "$1" ]; then
+                  raw=$(cat "$1" | sed -e 's/\r//g' | grep -Po --color=never '<coverage.+branch-rate="\K[^"]+')
+                  echo "$raw * 100" | bc -l | head -c 6
+              else
+                  echo 0
+              fi
+          }
+
+          get_record() {
+            local record=$(cat repos.csv | grep "^$1,$2,")
+            [ -z "$record" ] && record=$(cat repos.csv | grep "^$1,$3,")
+            echo $record
           }
 
           [ "$BRANCH" = "main" ] || BRANCH=latest
@@ -100,36 +108,34 @@ jobs:
           total_rate=$(get_branch "$RUNNER_TEMP/coverlet/reports/Cobertura.xml")
           integ_rate=$(get_branch "$integ_report")
           unit_rate=$(get_branch "$unit_report")
-          echo "Branch coverage rates for $REPO@${{ github.ref_name }} -- Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
+          echo "Branch coverage rates for $REPO@$BRANCH -- Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
 
           aws s3 cp $COVERAGE_S3_PATH repos.csv
-          record_exists=$(cat repos.csv | grep "^$REPO,$BRANCH," | wc -l)
+          record=$(get_record "$REPO" "$BRANCH" "main")
 
-          if [ "$record_exists" -gt 0 ]
+          if [ -n "$record" ]
           then
-            record=$(cat repos.csv | grep "^$REPO,$BRANCH,")
-            
-            total_persist=$(echo $record | cut -d, -f3)
-            integ_persist=$(echo $record | cut -d, -f4)
-            unit_persist=$(echo $record | cut -d, -f5)
+              total_persist=$(echo $record | cut -d, -f3)
+              integ_persist=$(echo $record | cut -d, -f4)
+              unit_persist=$(echo $record | cut -d, -f5)
 
-            if (( $(echo "$total_persist > $total_rate" | bc -l) ))
-            then
-              if (( $(echo "${{inputs.NEVER_FAIL_AT}} < $total_rate" | bc -l) ))
+              if (( $(echo "$total_persist > $total_rate" | bc -l) ))
               then
-                echo "::notice title=Branch coverage fallen::Test coverage has dropped from $total_persist to $total_rate, but is still above ${{inputs.NEVER_FAIL_AT}} "
+                  if (( $(echo "$NEVER_FAIL_AT < $total_rate" | bc -l) ))
+                  then
+                      echo "::notice title=Branch coverage fallen::Test coverage has dropped from $total_persist to $total_rate, but is still above $NEVER_FAIL_AT"
+                  else
+                      echo "::error title=Branch coverage failure::Test coverage has dropped from $total_persist to $total_rate"
+                      exit 1
+                  fi
               else
-                echo "::error title=Branch coverage failure::Test coverage has dropped from $total_persist to $total_rate"
-                exit 1
+                  echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"
               fi
-            else
-              echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"
-            fi
 
-            cat repos.csv | grep -v "^$REPO,$BRANCH," > repos.tmp
-            mv repos.tmp repos.csv
+              cat repos.csv | grep -v "^$REPO,$BRANCH," > repos.tmp
+              mv repos.tmp repos.csv
           else
-            echo "First time coverage reporting for $REPO@$BRANCH"
+              echo "First time coverage reporting for $REPO@$BRANCH"
           fi
 
           echo "$REPO,$BRANCH,$total_rate,$integ_rate,$unit_rate" >> repos.csv

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -5,15 +5,28 @@ name: Run XUnit Tests
 on:
   workflow_call:
     inputs:
-      BRANCH_THRESHOLD: # Test coverage threshold (integer): workflow will fail if branch coverage does not meet or exceed this threshold
-        required: true
-        type: number
       DOCKER_COMPOSE:   # Path to docker-compose.yml file: If populated, spins up containers required for integration tests
         type: string
+      BRANCH_THRESHOLD: # Test coverage threshold (integer): workflow will fail if branch coverage does not meet or exceed this threshold
+                        # If NOT populated, use historic data from previous runs as the threshold.
+                        # Historic data stored in S3, so the AWS secrets must be populated in this instance
+        type: number
+        default: 0
+      COVERAGE_S3_PATH: # S3 path of the CSV that stores historic coverage data (file can contain multiple repos/branches)
+        type: string
+      NEVER_FAIL_AT:
+        type: number
+        default: 0.95
+      AWS_REGION:
+        type: string
+        default: us-east-1
     secrets:
       PKG_TOKEN:
         required: true
-
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
 
 jobs:
   xunit:
@@ -47,10 +60,79 @@ jobs:
       - name: Run report generation
         run: reportgenerator -reports:$GITHUB_WORKSPACE/*/TestResults/*/coverage.cobertura.xml -targetdir:$RUNNER_TEMP/coverlet/reports -reporttypes:"cobertura"
 
-      - name: Check Branch Coverage
-        id: coverage
+      # Compare against static threshold (BRANCH_THRESHOLD is populated)
+      - name: Check Branch Coverage against static threshold
+        if: ${{ inputs.BRANCH_THRESHOLD > 0 }}
         uses: amdigital-co-uk/code-coverage-action@v1.0
         with:
           path: ${{ runner.temp }}/coverlet/reports/Cobertura.xml
           branch_minimum_threshold: ${{ inputs.BRANCH_THRESHOLD }}
+
+      # Compare against historic coverage (BRANCH_THRESHOLD is empty or 0, AWS secrets populated)
+      # Historic data stored in a CSV file in S3, and is updated if coverage improves.
+      - name: Configure AWS credentials
+        if: ${{ inputs.BRANCH_THRESHOLD <= 0 }}
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ inputs.AWS_REGION }}
+
+      - name: Check Branch Coverage against historic data
+        if: ${{ inputs.BRANCH_THRESHOLD <= 0 }}
+        env:
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}
+          COVERAGE_S3_PATH: ${{ inputs.COVERAGE_S3_PATH }}
+        run: |
+          get_branch() {
+            if [ -f "$1" ]; then
+              cat "$1" | sed -e 's/\r//g' | grep -Po --color=never '<coverage.+branch-rate="\K[^"]+' | head -c 6
+            else
+              echo 0
+            fi
+          }
+
+          [ "$BRANCH" = "main" ] || BRANCH=latest
+          integ_report=$(find . -iname coverage.cobertura.xml | grep "\.IntegrationTest")
+          unit_report=$(find . -iname coverage.cobertura.xml | grep "\.Test")
+
+          total_rate=$(get_branch "$RUNNER_TEMP/coverlet/reports/Cobertura.xml")
+          integ_rate=$(get_branch "$integ_report")
+          unit_rate=$(get_branch "$unit_report")
+          echo "Branch coverage rates for $REPO@${{ github.ref_name }} -- Total: $total_rate, IntegrationTests: $integ_rate, UnitTests: $unit_rate"
+
+          aws s3 cp $COVERAGE_S3_PATH repos.csv
+          record_exists=$(cat repos.csv | grep "^$REPO,$BRANCH," | wc -l)
+
+          if [ "$record_exists" -gt 0 ]
+          then
+            record=$(cat repos.csv | grep "^$REPO,$BRANCH,")
+            
+            total_persist=$(echo $record | cut -d, -f3)
+            integ_persist=$(echo $record | cut -d, -f4)
+            unit_persist=$(echo $record | cut -d, -f5)
+
+            if (( $(echo "$total_persist > $total_rate" | bc -l) ))
+            then
+              if (( $(echo "${{inputs.NEVER_FAIL_AT}} < $total_rate" | bc -l) ))
+              then
+                echo "::notice title=Branch coverage fallen::Test coverage has dropped from $total_persist to $total_rate, but is still above ${{inputs.NEVER_FAIL_AT}} "
+              else
+                echo "::error title=Branch coverage failure::Test coverage has dropped from $total_persist to $total_rate"
+                exit 1
+              fi
+            else
+              echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"
+            fi
+
+            cat repos.csv | grep -v "^$REPO,$BRANCH," > repos.tmp
+            mv repos.tmp repos.csv
+          else
+            echo "First time coverage reporting for $REPO@$BRANCH"
+          fi
+
+          echo "$REPO,$BRANCH,$total_rate,$integ_rate,$unit_rate" >> repos.csv
+          aws s3 cp repos.csv $COVERAGE_S3_PATH
+          exit 0
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Note that the secrets are defined at organisation level, so shouldn't need defin
 
 ## Run .NET Core automated tests via XUnit
 
+### Check branch coverage against Static Threshold
+
+Default behaviour when setting `BRANCH_THRESHOLD` is to report test coverage and fail the workflow if it does not meet the threshold.
+
 ```yml
 jobs:
   xunit:
@@ -17,6 +21,27 @@ jobs:
       BRANCH_THRESHOLD: 80
     secrets:
       PKG_TOKEN: ${{ secrets.PKG_TOKEN }}
+```
+
+### Check branch coverage against historic data
+
+Alternatively, when omitting `BRANCH_THRESHOLD` you can instead set the following parameters and secret values, to have the workflow check current test coverage against the last recorded test coverage for the same repository (test coverage values are stored in a CSV in S3 at the configured location).
+
+If coverage goes down, you see a failure; if it is maintained or improved, the new value will be persisted back to S3 as the new threshold for future runs.
+
+```yml
+jobs:
+  xunit:
+    uses: amdigital-co-uk/quartex-workflows/.github/workflows/xunit.yml@vNext
+    with:
+      DOCKER_COMPOSE: Quartex.Sample.Service.IntegrationTests/docker-compose.yml
+      COVERAGE_S3_PATH: s3://my-s3-bucket/code-coverage-reporting/repos.csv
+      AWS_REGION: us-west-2   # default is us-east-1
+      NEVER_FAIL_AT: 0.99     # default is 0.95
+    secrets:
+      PKG_TOKEN: ${{ secrets.PKG_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 ```
 
 ## Create and push NuGet packages to private GitHub packages feed

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
       DOCKER_COMPOSE: Quartex.Sample.Service.IntegrationTests/docker-compose.yml
       COVERAGE_S3_PATH: s3://my-s3-bucket/code-coverage-reporting/repos.csv
       AWS_REGION: us-west-2   # default is us-east-1
-      NEVER_FAIL_AT: 0.99     # default is 0.95
+      NEVER_FAIL_AT: 99     # default is 95
     secrets:
       PKG_TOKEN: ${{ secrets.PKG_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
- Store last-seen coverage values for each repo in a CSV (uploaded to S3)
- Run tests and generate coverage reports as previously
- Instead of using the existing `BRANCH_THRESHOLD` parameter, use the last seen-value from previous runs
  - If current test coverage is lower, then fail
  - If test coverage higher, persist the higher value to S3

Required change to calling workflows as follows:
- Add AWS related secrets
- Instead of specifying `BRANCH_THRESHOLD`, set `COVERAGE_S3_PATH` to indicate where the CSV lives

Updated workflow is backwards compatible, so using the existing input parameters without specifying the new ones will simply use the legacy behaviour. This is done by testing whether `BRANCH_THRESHOLD` is populated or not.