### PR TITLE
Make xunit.yml workflow more stable and able to accept missing coverage reports

### DIFF
--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -174,4 +174,8 @@ jobs:
 
       - name: List files in case of failure
         if: failure()
-        run: find .
+        run: |
+          find . | grep -v .git/
+          find . -iname coverage.cobertura.xml
+          find . -iname coverage.cobertura.xml | grep "\.IntegrationTest"
+          find . -iname coverage.cobertura.xml | grep "\.Test"

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -127,8 +127,8 @@ jobs:
           fi
 
           # Parse current branch coverage
-          integ_report=$(find . -iname coverage.cobertura.xml | grep "\.IntegrationTest")
-          unit_report=$(find . -iname coverage.cobertura.xml | grep "\.Test")
+          integ_report=$(find . -iname coverage.cobertura.xml | grep "\.IntegrationTest" || true)
+          unit_report=$(find . -iname coverage.cobertura.xml | grep "\.Test" || true)
           log_debug "integ_report=$integ_report, unit_report=$unit_report"
           total_rate=$(get_branch "$RUNNER_TEMP/coverlet/reports/Cobertura.xml")
           integ_rate=$(get_branch "$integ_report")
@@ -177,5 +177,5 @@ jobs:
         run: |
           find . | grep -v .git/
           find . -iname coverage.cobertura.xml
-          find . -iname coverage.cobertura.xml | grep "\.IntegrationTest"
-          find . -iname coverage.cobertura.xml | grep "\.Test"
+          find . -iname coverage.cobertura.xml | grep "\.IntegrationTest" || true
+          find . -iname coverage.cobertura.xml | grep "\.Test" || true

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -172,3 +172,6 @@ jobs:
 
           exit 0
 
+      - name: List files in case of failure
+        if: failure()
+        run: find .

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -20,6 +20,9 @@ on:
       AWS_REGION:
         type: string
         default: us-east-1
+      DEBUG:
+        type: string
+        default: FALSE
     secrets:
       PKG_TOKEN:
         required: true
@@ -86,6 +89,7 @@ jobs:
           COVERAGE_S3_PATH: ${{ inputs.COVERAGE_S3_PATH }}
           NEVER_FAIL_AT: ${{ inputs.NEVER_FAIL_AT }}
           PERSIST: false
+          DEBUG: ${{ inputs.DEBUG }}
         run: |
           # Utility Functions
           get_branch() {
@@ -103,6 +107,10 @@ jobs:
                   echo $record
           }
 
+          log_debug() {
+            [ "$DEBUG" = "true" ] && echo $@
+          }
+
           # Set behaviour based on current branch
           [ "$BRANCH" = "main" ] && PERSIST=true
           [ "$BRANCH" = "main" ] || BRANCH=latest
@@ -111,13 +119,17 @@ jobs:
 
           if [ ! -f "coverage.csv" ]
           then
+              log_debug "coverage.csv not present, creating placeholder"
               echo "Repository,Branch,Total Branch Rate,Integration Branch Rate,Unit Branch Rate"  > coverage.csv
               PERSIST=true
+          else
+              log_debug "coverage.csv downloaded OK"
           fi
 
           # Parse current branch coverage
           integ_report=$(find . -iname coverage.cobertura.xml | grep "\.IntegrationTest")
           unit_report=$(find . -iname coverage.cobertura.xml | grep "\.Test")
+          log_debug "integ_report=$integ_report, unit_report=$unit_report"
           total_rate=$(get_branch "$RUNNER_TEMP/coverlet/reports/Cobertura.xml")
           integ_rate=$(get_branch "$integ_report")
           unit_rate=$(get_branch "$unit_report")
@@ -126,6 +138,7 @@ jobs:
 
           # Parse historic coverage and cross-check
           record=$(get_record "$REPO" "main" "latest")
+          log_debug "$record"
 
           if [ -n "$record" ]
           then

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -92,6 +92,9 @@ jobs:
           DEBUG: ${{ inputs.DEBUG }}
         run: |
           # Utility Functions
+          log_debug() {
+            [ "$DEBUG" = "true" ] && echo $@
+          }
           get_branch() {
               if [ -f "$1" ]; then
                   raw=$(cat "$1" | sed -e 's/\r//g' | grep -Po --color=never '<coverage.+branch-rate="\K[^"]+')
@@ -100,23 +103,18 @@ jobs:
                   echo 0
               fi
           }
-
           get_record() {
                   local record=$(cat coverage.csv | grep "^$1,$2,")
                   [ -z "$record" ] && record=$(cat coverage.csv | grep "^$1,$3,")
                   echo $record
           }
 
-          log_debug() {
-            [ "$DEBUG" = "true" ] && echo $@
-          }
-
           # Set behaviour based on current branch
           [ "$BRANCH" = "main" ] && PERSIST=true
           [ "$BRANCH" = "main" ] || BRANCH=latest
 
+          # Retrieve or create coverage CSV
           aws s3 cp --quiet $COVERAGE_S3_PATH coverage.csv || true
-
           if [ ! -f "coverage.csv" ]
           then
               log_debug "coverage.csv not present, creating placeholder"
@@ -156,14 +154,14 @@ jobs:
                       exit 1
                   fi
               else
-                  echo "SUCCESS: Test coverage maintained from $total_persist to $total_rate"
+                  echo "::notice title=Branch coverage maintained::Test coverage maintained from $total_persist to $total_rate"
               fi
 
               # Remove current coverage values
               cat coverage.csv | grep -v "^$REPO,$BRANCH," > repos.tmp
               mv repos.tmp coverage.csv
           else
-              echo "::notice::First time coverage reporting for $REPO@$BRANCH"
+              echo "::notice::First time coverage reporting for $REPO@$BRANCH. Coverage is $total_rate"
           fi
 
           # Add new coverage values and persist
@@ -175,7 +173,5 @@ jobs:
       - name: List files in case of failure
         if: failure()
         run: |
-          find . | grep -v .git/
           find . -iname coverage.cobertura.xml
-          find . -iname coverage.cobertura.xml | grep "\.IntegrationTest" || true
-          find . -iname coverage.cobertura.xml | grep "\.Test" || true
+          find . | grep -v .git/


### PR DESCRIPTION
Primary issue was that when `grep` doesn't find any matches, it throws an error and the workflow dies. Using `grep [pattern] || true` seems to fix this issue.

Also added more verbose debugging output, which is only included when the calling workflow sets `DEBUG` to `true`.

Improved logging & formatting for the first-time reporting case.

See [working workflow run](https://github.com/amdigital-co-uk/qtms-permissions/runs/5408274840) on the `qtms-permissions` service.

[AB#3799](https://dev.azure.com/AMDigitalTech/9f385eba-1dbc-49f7-a4c1-2884596415cc/_workitems/edit/3799)