### PR TITLE
Configure AWS credentials via short-lived credentials and assumed IAM role

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,8 @@
 # CI workflow for Quartex .NET application
 name: Build and Package
+permissions:
+  id-token: write
+  contents: read
 
 # Define triggers for when the workflow will run
 on:
@@ -36,9 +39,7 @@ on:
     secrets:
       PKG_TOKEN:
         required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
+      AWS_ROLE_ARN:
         required: true
 
 jobs:
@@ -96,8 +97,8 @@ jobs:
       - name: Configure AWS credentials (ECR_REGION_1)
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-duration-seconds: 900
           aws-region: ${{ inputs.ECR_REGION_1 }}
       - name: Login to Amazon ECR (us-east-1)
         id: login-ecr-1
@@ -108,8 +109,8 @@ jobs:
         if: ${{ inputs.ECR_REGION_2 != '' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-duration-seconds: 900
           aws-region: ${{ inputs.ECR_REGION_2 }}
       - name: Login to Amazon ECR (us-east-2)
         if: ${{ inputs.ECR_REGION_2 != '' }}

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -1,5 +1,8 @@
 # Run unit tests
 name: Run XUnit Tests
+permissions:
+  id-token: write
+  contents: read
 
 # Define Parameters
 on:
@@ -26,10 +29,8 @@ on:
     secrets:
       PKG_TOKEN:
         required: true
-      AWS_ACCESS_KEY_ID:
-        required: false
-      AWS_SECRET_ACCESS_KEY:
-        required: false
+      AWS_ROLE_ARN:
+        required: true
 
 jobs:
   xunit:
@@ -77,8 +78,8 @@ jobs:
         if: ${{ inputs.BRANCH_THRESHOLD <= 0 }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-duration-seconds: 900
           aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Check Branch Coverage against historic data

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+This repository does not use our standard branching practices; instead, tags and refs are more important, since that is how calling workflows will reference specific versions of the workflows in this repository.
+
+The `main` branch is protected with a branch protection rule, so all work must be done in a temporary branch. Create a succinct branch name, as that will allow you to reference the WIP workflows via that git ref. E.g. if working on improvements to the performance of a workflow, you could create a branch called `vPerf`, and you would then be able to reference this WIP version of the workflow by branch name from another repo, e.g:
+
+```yml
+jobs:
+  xunit:
+    uses: amdigital-co-uk/quartex-workflows/.github/workflows/xunit.yml@vPerf
+    # etc
+```
+
+You can then issue a PR to merge your temp branch into `main`.
+
+# Tagging
+
+Once a branch has been thoroughly tested from external repositories (using the `vNext` style branch name/refs as above), and merged into main, you should then create a new tag. All external workflows would then need to use this new tag to reference this newly created version of the workflow.
+
+Tags should follow [SEMVER](https://semver.org/), except that trailing `.0`s can be ommitted (as this is cleaner). Typically, most version updates would be MAJOR version updates anyway, so in practice _most_ new tags will be a simple `v3` >> `v4` type update anyway.
+
+## Create tag
+
+```sh
+git tag v3
+git push origin v3
+```
+
+## Remove tag
+
+```sh
+git tag --delete v2.1.0-alpha
+git push --delete origin v2.1.0-alpha
+```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Quartex Workflows
 
+## Overview
+
 This repository contains [GitHub Actions](https://docs.github.com/en/actions) workflows used by the software team behind the [Quartex](https://www.quartexcollections.com/) platform, and form part of our CI/CD pipeline. This repository is public (as it is the only way Workflows can be be shared between repositories), although most of our other repositories are not.
 
-# Calling standard workflows for .NET code
+# Usage
 
-Note that the secrets are defined at organisation level, so shouldn't need defining within the repository, but they do need to be passed in to the called workflow.
+Note that our secrets are defined at organisation level. So whilst shouldn't need defining within the repository, they do need to be explicitly passed in to the called workflow.
 
 ## Run .NET Core automated tests via XUnit
 
@@ -25,14 +27,14 @@ jobs:
 
 ### Check branch coverage against historic data
 
-Alternatively, when omitting `BRANCH_THRESHOLD` you can instead set the following parameters and secret values, to have the workflow check current test coverage against the last recorded test coverage for the same repository (test coverage values are stored in a CSV in S3 at the configured location).
+Alternatively, when omitting `BRANCH_THRESHOLD` you can instead set the following parameters and secret values, to have the workflow check current test coverage against the last recorded test coverage for the same repository (test coverage values are stored in a CSV in S3 at the configured location). This is why we need to pass AWS authentication details to this workflow.
 
 If coverage goes down, you see a failure; if it is maintained or improved, the new value will be persisted back to S3 as the new threshold for future runs.
 
 ```yml
 jobs:
   xunit:
-    uses: amdigital-co-uk/quartex-workflows/.github/workflows/xunit.yml@v2
+    uses: amdigital-co-uk/quartex-workflows/.github/workflows/xunit.yml@v3
     with:
       DOCKER_COMPOSE: Quartex.Sample.Service.IntegrationTests/docker-compose.yml
       COVERAGE_S3_PATH: s3://my-s3-bucket/code-coverage-reporting/my-repo.csv # this path should be a unique CSV file for each repo
@@ -40,8 +42,7 @@ jobs:
       NEVER_FAIL_AT: 99     # default is 95
     secrets:
       PKG_TOKEN: ${{ secrets.PKG_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ROLE_ARN: ${{ secrets.PIPELINE_TESTS_ARN }}
 ```
 
 ## Create and push NuGet packages to private GitHub packages feed
@@ -66,7 +67,7 @@ Note this assumes our standard format of `Dockerfile`.
 jobs:
   dotnet:
     if: ${{ github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
-    uses: amdigital-co-uk/quartex-workflows/.github/workflows/dotnet.yml@v1
+    uses: amdigital-co-uk/quartex-workflows/.github/workflows/dotnet.yml@v3
     with:
       REF: ${{ github.ref }}
       PROJECT: Quartex.Sample.Service
@@ -78,6 +79,9 @@ jobs:
       ECR_REGION_2: us-east-2
     secrets:
       PKG_TOKEN: ${{ secrets.PKG_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ROLE_ARN: ${{ secrets.PIPELINE_ECR_ARN }}
 ```
+
+# Contributing
+
+See further details on [contributing](./CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 ## Overview
 
-This repository contains [GitHub Actions](https://docs.github.com/en/actions) workflows used by the software team behind the [Quartex](https://www.quartexcollections.com/) platform, and form part of our CI/CD pipeline. This repository is public (as it is the only way Workflows can be be shared between repositories), although most of our other repositories are not.
+This repository contains workflows used by the software team behind the [Quartex](https://www.quartexcollections.com/) platform, and form part of our CI/CD pipeline. This repository is public (as it is the only way Workflows can be be shared between repositories), although most of our other repositories are not.
+
+## Built with
+
+- [GitHub Actions](https://docs.github.com/en/actions)
+- [bash](https://www.gnu.org/software/bash/)
 
 # Usage
 


### PR DESCRIPTION
Instead of passing in secrets for the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, which can be insecure - use the approach of [generating short-lived credentials](https://benoitboure.com/securely-access-your-aws-resources-from-github-actions).

Also document most of the standard README sections for this repo.