### PR TITLE
Correct ironic issue with log_debug function

### DIFF
--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           # Utility Functions
           log_debug() {
-            [ "$DEBUG" = "true" ] && echo $@
+            if [ "$DEBUG" = "true" ]; then echo $@; fi
           }
           get_branch() {
               if [ -f "$1" ]; then


### PR DESCRIPTION
Scripts in GitHub Actions evidently run with `set -e` enabled, which means that if any single command returns a non-zero exit code, the step will fail.

Ironically enough, the `log_debug` function itself will return non-zero if the `DEBUG` parameter is not set to true. This has the effect of making the step fail at the first instance of debug logging, _unless_ debugging is enabled!

[Further reading](http://redsymbol.net/articles/unofficial-bash-strict-mode/) on `set -e`.