### PR TITLE
Fix shared configs workflow steps

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,6 +37,7 @@ on:
         type: boolean
         default: false
     secrets:
+      SRC_TOKEN:
       PKG_TOKEN:
         required: true
       AWS_ROLE_ARN:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,8 +37,6 @@ on:
         type: boolean
         default: false
     secrets:
-      SRC_TOKEN:
-        required: false
       PKG_TOKEN:
         required: true
       AWS_ROLE_ARN:
@@ -88,7 +86,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ inputs.CONFIGS }}
-          token: ${{ secrets.SRC_TOKEN }}
           path: config
       - name: Copy shared configuration into project
         if: ${{ inputs.CONFIGS != '' }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ on:
         required: true
         type: string
       CONFIGS:      # Configuration repository name: Populate if raw config files are required by the application
-        type: boolean
+        type: string
       DK_NAMESPACE: # Docker Namespace: Typically this will be 'qtms' for a microservice or 'qtui' for a webapp
         required: true
         type: string

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,6 +37,8 @@ on:
         type: boolean
         default: false
     secrets:
+      SRC_TOKEN:
+        required: false
       PKG_TOKEN:
         required: true
       AWS_ROLE_ARN:
@@ -86,6 +88,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ inputs.CONFIGS }}
+          token: ${{ secrets.SRC_TOKEN }}
           path: config
       - name: Copy shared configuration into project
         if: ${{ inputs.CONFIGS != '' }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -89,7 +89,7 @@ jobs:
           token: ${{ secrets.SRC_TOKEN }}
           path: config
       - name: Copy shared configuration into project
-        if: ${{ inputs.CONFIGS == 'true' }}
+        if: ${{ inputs.CONFIGS != '' }}
         run: cp config/*/*.json $PROJECT
 
       # Login to ECR_REGION_1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -38,6 +38,7 @@ on:
         default: false
     secrets:
       SRC_TOKEN:
+        required: false
       PKG_TOKEN:
         required: true
       AWS_ROLE_ARN:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -92,7 +92,7 @@ jobs:
           path: config
       - name: Copy shared configuration into project
         if: ${{ inputs.CONFIGS != '' }}
-        run: cp config/*/*.json $PROJECT
+        run: cp config/*/*.json ${{ inputs.PROJECT }}
 
       # Login to ECR_REGION_1
       # See https://github.com/marketplace/actions/amazon-ecr-login-action-for-github-actions

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ jobs:
       DK_TAG: latest
       ECR_REGION_1: us-east-1
       ECR_REGION_2: us-east-2
+      CONFIGS: org/config-repo # Optional: specify a repo to checkout and retrieve JSON configs from
     secrets:
       PKG_TOKEN: ${{ secrets.PKG_TOKEN }}
       AWS_ROLE_ARN: ${{ secrets.PIPELINE_ECR_ARN }}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ jobs:
       CONFIGS: org/config-repo # Optional: specify a repo to checkout and retrieve JSON configs from
     secrets:
       PKG_TOKEN: ${{ secrets.PKG_TOKEN }}
+      SRC_TOKEN: ${{ github.token }} # Must be specified if CONFIGS is set; must be a token that has read access to the repo
       AWS_ROLE_ARN: ${{ secrets.PIPELINE_ECR_ARN }}
 ```
 


### PR DESCRIPTION
The condition on the dotnet.yml workflow that copies in JSON configuration files was faulty.
The `CONFIGS` input parameter should contain the name of the repo to copy configs in from, however the `if` statement on the workflow step assumed it was a boolean. The condition should be true if the input is non-empty.