### PR TITLE
Update naming schemes and fix bash IF statement

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -124,5 +124,8 @@ jobs:
           cd ${{ inputs.WORKDIR }}
           docker build . -t $DK_REG_1/$DK_NAMESPACE/$DK_IMAGE:$TAG
           docker push $DK_REG_1/$DK_NAMESPACE/$DK_IMAGE:$TAG
-          [ -n "$DK_REG_2" ] && docker tag $DK_REG_1/$DK_NAMESPACE/$DK_IMAGE:$TAG $DK_REG_2/$DK_NAMESPACE/$DK_IMAGE:$TAG
-          [ -n "$DK_REG_2" ] && docker push $DK_REG_2/$DK_NAMESPACE/$DK_IMAGE:$TAG
+          if [ -n "$ECR_REGION_2" ] && [ -n "$DK_REG_2" ] 
+          then 
+            docker tag $DK_REG_1/$DK_NAMESPACE/$DK_IMAGE:$TAG $DK_REG_2/$DK_NAMESPACE/$DK_IMAGE:$TAG
+            docker push $DK_REG_2/$DK_NAMESPACE/$DK_IMAGE:$TAG
+          fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,6 +69,10 @@ jobs:
             SCC_BRANCH=$REF
             echo "Branch/Tag parsing: DEFAULT case -- REF=$REF"
           fi
+          
+          [[ "$SCC_BRANCH" == feature/* ]] && DK_TAG=feature-$(echo ${SCC_BRANCH#feature/})
+          [[ "$SCC_BRANCH" == bug/* ]] && DK_TAG=fix-$(echo ${SCC_BRANCH#bug/})
+          [[ "$SCC_BRANCH" == release/* ]] && DK_TAG=release-$(echo ${SCC_BRANCH#release/})
           [[ "$SCC_BRANCH" == stage/* ]] && TAG=$(echo ${SCC_BRANCH#stage/})
           [[ "$SCC_TAG" == v* ]] && TAG=$SCC_TAG
           echo "BRANCH=$SCC_BRANCH"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -168,5 +168,8 @@ jobs:
           [ -n "$REACT_PROJECT" ] && REACT_ARG="--build-arg BUILD_REACT_PROJECT=$REACT_PROJECT"
           docker build . -f $DK_FILE -t $DK_REG_1/$DK_NAMESPACE/$DK_IMAGE:$DK_TAG --build-arg BUILD_PROJECT=$PROJECT --build-arg BUILD_TAG=$DK_TAG --build-arg BUILD_COMPONENT=$COMPONENT $REACT_ARG
           docker push $DK_REG_1/$DK_NAMESPACE/$DK_IMAGE:$DK_TAG
-          [ -n "$DK_REG_2" ] && docker tag $DK_REG_1/$DK_NAMESPACE/$DK_IMAGE:$DK_TAG $DK_REG_2/$DK_NAMESPACE/$DK_IMAGE:$DK_TAG
-          [ -n "$DK_REG_2" ] && docker push $DK_REG_2/$DK_NAMESPACE/$DK_IMAGE:$DK_TAG
+          if [ -n "$DK_REG_2" ]
+          then
+            docker tag $DK_REG_1/$DK_NAMESPACE/$DK_IMAGE:$DK_TAG $DK_REG_2/$DK_NAMESPACE/$DK_IMAGE:$DK_TAG
+            docker push $DK_REG_2/$DK_NAMESPACE/$DK_IMAGE:$DK_TAG
+          fi


### PR DESCRIPTION
Due to using bash one-line if statements, workflows were finishing with an error status if the `DK_REG_2` property was not specified.

- Apply the bash IF fix to both the `docker.yml` and `dotnet.yml` workflows
- Update the `docker.yml` workflow to be able to use any of our branching strategies