### PR TITLE
Fix the generation of the API NPM package

### DIFF
--- a/.github/workflows/api-npm.yml
+++ b/.github/workflows/api-npm.yml
@@ -56,10 +56,12 @@ jobs:
           VERSION=$(cat $NAMESPACE/$NAMESPACE.csproj | grep "<Version>" | cut -d ">" -f 2 | cut -d "<" -f1)
           cd ${{ inputs.PROJECT }}
           cat << EFO > Program.cs
-          using Quartex.ServiceClient.ScriptGenerator;
           public class Program
           {
-              public static void Main(string[] args) => new RequestScriptsGenerator().Run(args);
+              public static void Main(string[] args) {
+                System.Reflection.Assembly.Load("$NAMESPACE");
+                new Quartex.ServiceClient.ScriptGenerator.RequestScriptsGenerator().Run(args);
+              }
           }
           EOF
           dotnet restore && dotnet build

--- a/.github/workflows/api-npm.yml
+++ b/.github/workflows/api-npm.yml
@@ -52,10 +52,16 @@ jobs:
       - name: Generate NPM package
         env:
           NAMESPACE: ${{ inputs.NAMESPACE }}
-        run: |
+        run: | # Create minimal Program.cs file to just run the RequestScriptsGenerator
           VERSION=$(cat $NAMESPACE/$NAMESPACE.csproj | grep "<Version>" | cut -d ">" -f 2 | cut -d "<" -f1)
           cd ${{ inputs.PROJECT }}
-          echo "{}" > compiled-config.json
+          cat << EFO > Program.cs
+          using Quartex.ServiceClient.ScriptGenerator;
+          public class Program
+          {
+              public static void Main(string[] args) => new RequestScriptsGenerator().Run(args);
+          }
+          EOF
           dotnet restore && dotnet build
           dotnet run --generate-api-ts .. ${{ inputs.PREFIX }} ${{ inputs.NAMESPACE }} "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" ${{ inputs.NPM_SCOPE }}/${{ inputs.PACKAGE }} $VERSION
           cat ../package.json

--- a/.github/workflows/api-npm.yml
+++ b/.github/workflows/api-npm.yml
@@ -55,7 +55,7 @@ jobs:
         run: | # Create minimal Program.cs file to just run the RequestScriptsGenerator
           VERSION=$(cat $NAMESPACE/$NAMESPACE.csproj | grep "<Version>" | cut -d ">" -f 2 | cut -d "<" -f1)
           cd ${{ inputs.PROJECT }}
-          cat << EFO > Program.cs
+          cat << EOF > Program.cs
           public class Program
           {
               public static void Main(string[] args) {

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Settings
+.vscode/*


### PR DESCRIPTION
This PR fixes the generation of the API NPM package in C#, by generating a minimal `Program.cs` to do the generation work.

Previous iterations that used the existing microservice's code have run into issues where the `Startup.cs` brings in lots of dependencies that don't exist in a pipeline.