### PR TITLE
Fix 'Invalid Input" error when specifying .NET version to use

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -47,7 +47,6 @@ on:
       DOTNET_VERSION:
         required: false
         type: string
-        default: null
     secrets:
       SRC_TOKEN:
         required: false

--- a/.github/workflows/xunit.yml
+++ b/.github/workflows/xunit.yml
@@ -29,7 +29,6 @@ on:
       DOTNET_VERSION:
         required: false
         type: string
-        default: null
       CONFIG_FILE_S3_ROOT:
         required: false
         type: string


### PR DESCRIPTION
Fixes the following issue:

When specifying the .NET version(s) to use as below...

```yml
jobs:
  xunit:
    uses: amdigital-co-uk/quartex-workflows/.github/workflows/xunit.yml@v3
    with:
      DOTNET_VERSION: 5.0.x
```

The workflow run fails with error "Invalid input, DOTNET_VERSION is not defined in the referenced workflow".